### PR TITLE
docs: fix simple typo, utlities -> utilities

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -1,5 +1,5 @@
 /**
- * utils.c - Defines for various utlities.  Part of the FSSB project.
+ * utils.c - Defines for various utilities.  Part of the FSSB project.
  *
  * Copyright (C) 2016 Adhityaa Chandrasekar
  *


### PR DESCRIPTION
There is a small typo in utils.h.

Should read `utilities` rather than `utlities`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md